### PR TITLE
Add bond printer spec and service skeleton

### DIFF
--- a/BOND_PRINTER_SPEC.md
+++ b/BOND_PRINTER_SPEC.md
@@ -1,0 +1,76 @@
+# Chrononomic Bond Printer
+
+This document describes the requirements and high-level design of the **Chrononomic Bond Printer**, a system for minting and issuing χ‑denominated bond certificates.
+
+## 1. Overview
+
+The Bond Printer allows authorized underwriters to mint Chrononomic Bonds on demand. Certificates are generated as PDFs (optionally printable) and are linked to on-chain metadata through an ERC‑721 contract. Compliance information and audit logs are recorded for each issuance.
+
+## 2. Objectives
+
+- **Rapid Issuance** – create new bond tranches in minutes.
+- **Smart Contract Integration** – automate minting and lifecycle events.
+- **Certificate Generation** – produce human‑readable PDFs with digital signatures and QR codes.
+- **Compliance & Audit** – embed KYC/AML data and maintain immutable logs.
+- **Branded Templates** – support custom layouts with issuer branding.
+
+## 3. Functional Requirements
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **User Roles & Permissions** | Underwriter, Compliance Officer and Auditor roles; only Underwriters may mint. |
+| **Bond Parameters Input** | Face value (χ), coupon schedule, maturity date in Chronons, tranche ID and series metadata. |
+| **On‑Chain Minting** | Invoke the ERC‑721 `Chronobond` contract to mint tokens linked to bond metadata. |
+| **Certificate Generation** | Populate a PDF template with metadata and a QR code pointing to on‑chain data. |
+| **Physical Print Support** | Optional secure pipeline for PDF‑to‑printer workflows. |
+| **Regulatory Disclosure Panel** | Embed mandatory disclosures per jurisdiction. |
+| **Audit Log & Versioning** | Record every issuance and revision in the Compliance DB. |
+
+## 4. System Architecture
+
+```
+Executive Portal UI → Bond Printer Service → Chronobond Smart Contract
+            ↑                   ↓
+    Compliance Database    PDF Generation Engine
+```
+
+The portal provides a wizard for bond creation. The service validates input, submits blockchain transactions and generates certificates using HTML templates. Audit logs are stored in a Postgres database.
+
+## 5. Smart‑Contract Highlights
+
+```solidity
+interface IChronobond {
+    function mintBond(
+        address to,
+        uint256 faceValue,
+        uint256 couponRate,
+        uint256 maturityChronon,
+        string calldata metadataURI
+    ) external returns (uint256 bondId);
+}
+```
+
+`metadataURI` points to a JSON manifest that includes series information, issue date, coupon schedule and a hash of the generated PDF for verification.
+
+## 6. Certificate Template
+
+Certificates display the bond title, holder details and a terms table. The footer includes a QR code linking to on‑chain metadata and digital signature blocks.
+
+## 7. Security & Compliance
+
+- OAuth2 with role‑based access.
+- Sensitive data encrypted at rest; only hashes on‑chain.
+- Immutable audit records for every action.
+- Optional hardware security module (HSM) integration for physical print seals.
+
+## 8. Implementation Roadmap
+
+| Phase | Deliverable | ETA |
+| ----- | ----------- | --- |
+| 1 | API & smart contract integration | Q3 2025 |
+| 2 | PDF template engine and sample certificates | Q3 2025 |
+| 3 | Executive Portal integration | Q4 2025 |
+| 4 | Compliance workflows and audit logging | Q4 2025 |
+| 5 | Physical print support | H1 2026 |
+
+This document serves as a starting point for development of the Bond Printer modules in this repository.

--- a/services/bond-printer-service.ts
+++ b/services/bond-printer-service.ts
@@ -1,0 +1,80 @@
+import { ethers } from "ethers"
+import { jsPDF } from "jspdf"
+import autoTable from "jspdf-autotable"
+import ChrononBondABI from "@/contracts/ChrononBond.json"
+import { CONTRACT_ADDRESSES } from "@/config/contracts"
+
+export interface MintBondParams {
+  to: string
+  faceValue: string
+  couponRate: string
+  maturityChronon: number
+  metadataURI: string
+}
+
+export async function mintBond(
+  params: MintBondParams,
+  signer: ethers.Signer,
+  chainId: number,
+): Promise<number> {
+  const addresses = CONTRACT_ADDRESSES[chainId] || {}
+  if (!addresses.ChrononBond) {
+    throw new Error("Bond contract address not found for this network")
+  }
+
+  const bondContract = new ethers.Contract(addresses.ChrononBond, ChrononBondABI.abi, signer)
+
+  const tx = await bondContract.mintBond(
+    params.to,
+    ethers.utils.parseUnits(params.faceValue, 18),
+    params.couponRate,
+    params.maturityChronon,
+    params.metadataURI,
+  )
+
+  const receipt = await tx.wait()
+  const event = receipt.events?.find((e: any) => e.event === "BondMinted")
+  return event ? event.args.bondId.toNumber() : 0
+}
+
+export interface CertificateMetadata {
+  bondId: number
+  faceValue: string
+  couponRate: string
+  maturityChronon: number
+  series: string
+  issueDate: string
+  holderName?: string
+}
+
+export function generateBondCertificate(meta: CertificateMetadata): Uint8Array {
+  const doc = new jsPDF()
+
+  doc.setFontSize(16)
+  doc.text("Chrononomic Bond Certificate", 20, 20)
+  doc.setFontSize(12)
+  doc.text(`Bond ID: ${meta.bondId}`, 20, 30)
+  doc.text(`Series: ${meta.series}`, 20, 40)
+  doc.text(`Face Value: ${meta.faceValue} χ`, 20, 50)
+  doc.text(`Coupon Rate: ${meta.couponRate}%`, 20, 60)
+  doc.text(`Maturity (Chronon): ${meta.maturityChronon}`, 20, 70)
+  doc.text(`Issue Date: ${meta.issueDate}`, 20, 80)
+  if (meta.holderName) {
+    doc.text(`Holder: ${meta.holderName}`, 20, 90)
+  }
+
+  autoTable(doc, {
+    startY: 100,
+    head: [["Field", "Value"]],
+    body: [
+      ["Bond ID", meta.bondId.toString()],
+      ["Series", meta.series],
+      ["Face Value", `${meta.faceValue} χ`],
+      ["Coupon Rate", `${meta.couponRate}%`],
+      ["Maturity", meta.maturityChronon.toString()],
+      ["Issue Date", meta.issueDate],
+    ],
+  })
+
+  return doc.output("arraybuffer") as Uint8Array
+}


### PR DESCRIPTION
## Summary
- document Chrononomic Bond Printer specification
- add a skeletal bond-printer-service with minting and PDF generation helpers

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68477aece35c8326a0aef28dc9e652ee